### PR TITLE
fix: add bounds check before memcpy in rtx_vsr_host.cpp

### DIFF
--- a/vsr_host/rtx_vsr_host.cpp
+++ b/vsr_host/rtx_vsr_host.cpp
@@ -352,7 +352,7 @@ extern "C" __declspec(dllexport) int vsr_upscale(const unsigned char* src, int s
 
     {
         uint8_t* mapped = nullptr;
-        if (FAILED(sf.upload->Map(0, nullptr, (void**)&mapped))) return 0;
+        if (FAILED(sf.upload->Map(0, nullptr, (void**)&mapped)) || !mapped) return 0;
         for (int y = 0; y < sh; ++y)
             memcpy(mapped + (UINT64)y * sf.inPitch, src + (UINT64)y * sw * 4, (UINT64)sw * 4);
         sf.upload->Unmap(0, nullptr);
@@ -426,7 +426,7 @@ extern "C" __declspec(dllexport) int vsr_upscale(const unsigned char* src, int s
 
     {
         uint8_t* mapped = nullptr;
-        if (FAILED(sf.readback->Map(0, nullptr, (void**)&mapped))) return 0;
+        if (FAILED(sf.readback->Map(0, nullptr, (void**)&mapped)) || !mapped) return 0;
         for (int y = 0; y < dh; ++y)
             memcpy(dst + (UINT64)y * dw * 4, mapped + (UINT64)y * sf.outPitch, (UINT64)dw * 4);
         sf.readback->Unmap(0, nullptr);


### PR DESCRIPTION
## Summary
Fix high severity security issue in `vsr_host/rtx_vsr_host.cpp`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `vsr_host/rtx_vsr_host.cpp:355` |
| **Assessment** | Likely exploitable |

**Description**: The D3D12 Map() function is called and the result is checked for failure, but the returned 'mapped' pointer is not validated for NULL before being dereferenced in memcpy operations. While FAILED() checks the HRESULT, Map() could succeed but still return a NULL pointer in edge cases such as GPU device removal or memory pressure conditions.

## Evidence

**Exploitation scenario**: An attacker triggers GPU resource exhaustion or device removal events (e.g., by processing many large images simultaneously or triggering driver errors).

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `vsr_host/rtx_vsr_host.cpp`

> **Note**: The following lines in the same file use a similar pattern and may also need review: `vsr_host/rtx_vsr_host.cpp:357`, `vsr_host/rtx_vsr_host.cpp:431`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
